### PR TITLE
Define _GNU_SOURCE to avoid pulling in a incompatible

### DIFF
--- a/sources/strerror_r.c
+++ b/sources/strerror_r.c
@@ -5,6 +5,8 @@
  *      Author: ardi
  */
 
+#define _GNU_SOURCE
+
 #include <string.h>
 
 char* strerror_r (int errnum, char *buf, size_t bufsize) {


### PR DESCRIPTION
declaration