### PR TITLE
Only include <memory.h> for MintLib compatibility

### DIFF
--- a/sources/atexit.c
+++ b/sources/atexit.c
@@ -4,7 +4,9 @@
 
 #include <stddef.h>
 #include <stdlib.h>
+#ifdef __MINTLIB_COMPATIBLE
 #include <memory.h>
+#endif
 
 #include "lib.h"
 

--- a/sources/realloc.c
+++ b/sources/realloc.c
@@ -1,8 +1,10 @@
 #include <stddef.h>	/* for size_t */
 #include <stdlib.h>
+#ifdef __MINTLIB_COMPATIBLE
 #include <memory.h>
-#include <string.h>
 #include <unistd.h>
+#endif
+#include <string.h>
 #include "lib.h"
 
 


### PR DESCRIPTION
memory.h and unistd.h are only provided by MintLib. Unconditionally
including them will require the mintlib headers, and may pull in
other headers resulting in redefinitions