### PR TITLE
Fix atoi and atol as per spec

### DIFF
--- a/sources/atoi.c
+++ b/sources/atoi.c
@@ -15,6 +15,9 @@
 int atoi(const char *c)
 {
     int value = 0;
+
+    while (isspace(*c)) c++;
+
     while (isdigit(*c))
     {
         value *= 10;

--- a/sources/atol.c
+++ b/sources/atol.c
@@ -15,6 +15,9 @@
 long atol(const char *c)
 {
     long value = 0;
+
+    while (isspace(*c)) c++;
+    
     while (isdigit(*c))
     {
         value *= 10;


### PR DESCRIPTION
Spec requires that atoi and atol ignore whitespaces before the number.