### PR TITLE
Fix strlen

### DIFF
--- a/sources/strlen.c
+++ b/sources/strlen.c
@@ -11,7 +11,7 @@ size_t strlen(const char *s)
 {
 	const char *start = s;
 
-	while (*s++);
+	while (*s) s++;
 
 	return s - start - 1;
 }


### PR DESCRIPTION
Strlen calculates the string length with pointer math, but unfortunatly
the loop uses post-increment event when terminating character is detected.
This leads to the pointer going past the terminating character and causing
off by one error when calculating the length.