### PR TITLE
Revert errounous change in strlen and workaround a bug(?) in a compiler?

### DIFF
--- a/sources/strcmp.c
+++ b/sources/strcmp.c
@@ -9,10 +9,9 @@
 
 int strcmp(const char *s1, const char *s2)
 {
-	int i;
 	int cmp;
 
-	for (i = 0; *s1++ && *s2++; i++)
+	for (; *s1++ && *s2++;)
 	{
 		cmp = (*s1 - *s2);
 		if (cmp != 0) return cmp;

--- a/sources/strlen.c
+++ b/sources/strlen.c
@@ -11,7 +11,7 @@ size_t strlen(const char *s)
 {
 	const char *start = s;
 
-	while (*s) s++;
+	while (*s++);
 
 	return s - start - 1;
 }

--- a/sources/strncmp.c
+++ b/sources/strncmp.c
@@ -9,13 +9,15 @@
 
 int strncmp(const char *s1, const char *s2, size_t max)
 {
-	int i;
+	size_t i;
 	int cmp;
 
-	for (i = 0; i < max && *s1++ && *s2++; i++)
+	for (i = 0; i < max && *s1 && *s2; i++)
 	{
 		cmp = (*s1 - *s2);
 		if (cmp != 0) return cmp;
+		s1++;
+		s2++;
 	}
 	return cmp;
 }


### PR DESCRIPTION
I'd appreciate @mfro0  if you could look at my strncmp findings.