### PR TITLE
scanf - Return number of matched input items

### DIFF
--- a/sources/scanf.c
+++ b/sources/scanf.c
@@ -453,6 +453,7 @@ static __inline int _sscanf(const char *_pstring, const char *_pformat, va_list 
     int modeflags;
     int format_length;
     int format_recovery = 0;
+    int found_items = 0;
 
     const char *pformat = _pformat;
     const char *pstring = _pstring;
@@ -686,7 +687,7 @@ modifier_recover:
             case 'n':	// not that useful...
             case '[':	// todo: better support this one
                 printf("sscanf: error - unsupported format pattern '%%%c'\n", cf);
-                return 0;
+                return found_items;
                 break;
             }
         }
@@ -694,11 +695,12 @@ modifier_recover:
         {
             // not [whitespace], not [string], not [%format] = failure
             printf("sscanf: error - format:string desync\n");
-            return 0;
+            return found_items;
         }
+        found_items++;
     }
 
-    return 1;
+    return found_items;
 } // _sscanf
 
 


### PR DESCRIPTION
libcmini's current scanf implementation only returns 0 (in case of any failure) or 1 (in case of success). However, scanf (and fscanf, sscanf, ...) is supposed to return the number of input items that were matched.

Consider the following test program:
```c
#include <stdio.h>
 
int main(void) {
    int data1, data2, data3;
    int ret;

    ret = sscanf("123 456 789", "%d", &data1);
    printf("Found %d item(s)\n", ret);

    ret = sscanf("123 456 789", "%d %d", &data1, &data2);
    printf("Found %d item(s)\n", ret);

    ret = sscanf("123 456 789", "%d %d %d", &data1, &data2, &data3);
    printf("Found %d item(s)\n", ret);

    ret = sscanf("123 FOO 789", "%d %d %d", &data1, &data2, &data3);
    printf("Found %d item(s)\n", ret);

    ret = sscanf("123 456 789", "%d FOO %d", &data1, &data2);
    printf("Found %d item(s)\n", ret);

    return 0;
}
```

With glibc (on the host) or MiNTLib (on the Atari), it'll return 1, 2, 3, 1 and 1 items respectively. The output when using libcmini, however, is:
```
Found 1 item(s)
Found 1 item(s)
Found 1 item(s)
Found 1 item(s)
sscanf: error - format:string desync
Found 0 item(s)
```

This pull request improves the situation by counting the number of input items. Note that the error handling is still not 100% accurate after applying this change. This can be seen from the fourth line:
```
Found 1 item(s)
Found 2 item(s)
Found 3 item(s)
Found 3 item(s)
sscanf: error - format:string desync
Found 1 item(s)
```

This is because scan_atoi() etc. don't have a way to signal an illegal number: https://github.com/mfro0/libcmini/blob/a7a3658de3a52bc7b812b425421fb2de86a80f0a/sources/scanf.c#L274

However, this pull request is "good enough" so that uiptool can be compiled with libcmini. (Therefore, I suppose @sqward has also encountered this issue.)