### PR TITLE
Crap in vs(n)printf.c removed

### DIFF
--- a/sources/vsnprintf.c
+++ b/sources/vsnprintf.c
@@ -30,8 +30,7 @@ int vsnprintf(char *str, size_t size, const char *fmt, va_list va)
 	stream.xstring = str;
 	stream.xestring = str + size - 1;
 	doprnt(addchar, &stream, fmt, va);
-	*stream.xstring++ = '\0';
+	*stream.xstring = '\0';
 
-	/* -1 on the account of terminating 0 */
-	return stream.xstring - str - 1;
+	return stream.xstring - str;
 }

--- a/sources/vsprintf.c
+++ b/sources/vsprintf.c
@@ -15,8 +15,7 @@ int vsprintf(char *str, const char *format, va_list va)
 	stream.xestring = 0;
 
 	doprnt(addchar, &stream, format, va);
-	*stream.xstring++ = '\0';
+	*stream.xstring = '\0';
 
-	/* -1 on the account of terminating 0 */
-	return stream.xstring - str - 1;
+	return stream.xstring - str;
 }


### PR DESCRIPTION
Why increment stream.xstring and subtract 1 upon return?