### PR TITLE
Add timezone support

### DIFF
--- a/include/time.h
+++ b/include/time.h
@@ -32,13 +32,25 @@ struct timeval
 
 struct timezone
 {
-	int tz_minuteswest;		/* minutes west of Greenwich */
-	int tz_dsttime;			/* type of DST correction */
+	int tz_minuteswest;		/* minutes west of GMT */
+	int tz_dsttime;			/* Nonzero if DST is ever in effect */
 };
 
+/*
+Time functions assume that the BIOS clock uses local time.
+If your clock uses GMT and your local time is not, uncomment this.
+
+#define GMT_BIOS_CLOCK
+*/
+
+extern long timezone;
+extern char* tzname[2];
+
 extern time_t time(time_t *tloc);
+extern void tzset();
 extern clock_t clock(void);
 extern time_t mktime(struct tm *tm);
+extern struct tm* gmtime(const time_t* timep);
 extern struct tm* localtime(const time_t* timep);
 extern size_t strftime(char* s, size_t smax, const char* fmt, const struct tm* tp);
 

--- a/include/time.h
+++ b/include/time.h
@@ -36,13 +36,6 @@ struct timezone
 	int tz_dsttime;			/* Nonzero if DST is ever in effect */
 };
 
-/*
-Time functions assume that the BIOS clock uses local time.
-If your clock uses GMT and your local time is not, uncomment this.
-
-#define GMT_BIOS_CLOCK
-*/
-
 extern long timezone;
 extern char* tzname[2];
 

--- a/sources/gmtime.c
+++ b/sources/gmtime.c
@@ -1,0 +1,105 @@
+#include <time.h>
+#include <osbind.h>
+
+#ifdef __MINTLIB_COMPATIBLE
+# include <sys/time.h>
+#endif /* __MINTLIB_COMPATIBLE */
+
+
+/* year range is from 1901 to 2038, so no century can occur which is not a leap year
+#define is_leap(y)  ((y) % 4 == 0 && ((y) % 100 != 0 || (y) % 400 == 0))
+*/
+#define is_leap(y)  ((y) % 4 == 0)
+
+
+const long _month_days[] = { 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31 };
+
+enum { January, February, March, April, May, June, July, August, September, October, November, December, Months };
+enum { Sunday, Monday, Tuesday, Wednesday, Thursday, Friday, Saturday, Weekdays };
+
+
+struct tm*
+gmtime(const time_t* timep)
+{
+    static struct tm tm;
+
+    time_t t   = *timep;
+    int    neg = (t < 0);
+    int    step;
+    int    days;
+    int    seconds;
+    int    leap;
+    int    monthdays;
+
+    if (neg) {
+        t    = -t - 1;
+        step = -1;
+    } else {
+        step = 1;
+    }
+
+    days    = t / 86400;
+    seconds = t % 86400;
+
+    if (neg) {
+        tm.tm_wday = (Wednesday + days) % Weekdays;
+        tm.tm_year = 1969;
+        seconds    = 86399 - seconds;
+    } else {
+        tm.tm_wday = (Thursday + days) % Weekdays;
+        tm.tm_year = 1970;
+    }
+
+    for (;;) {
+        int yeardays = is_leap(tm.tm_year) ? 366 : 365;
+
+        if (neg) {
+            if (yeardays > days) {
+                tm.tm_yday = yeardays - days - 1;
+                break;
+            }
+        } else {
+            if (yeardays >= days) {
+                tm.tm_yday = days;
+                break;
+            }
+        }
+
+        tm.tm_year += step;
+        days       -= yeardays;
+    }
+
+    tm.tm_mon = neg ? 11 : 0;
+
+    leap = is_leap(tm.tm_year);
+
+    for (;;) {
+        monthdays = _month_days[tm.tm_mon];
+
+        if (leap && tm.tm_mon == 1) {
+            ++monthdays;
+        }
+
+        if (monthdays <= days) {
+            tm.tm_mon += step;
+            days      -= monthdays;
+
+            if (tm.tm_mon == 12) {
+                tm.tm_mon = 0;
+                ++tm.tm_year;
+            }
+        } else {
+            tm.tm_mday = neg ? monthdays : 1;
+            break;
+        }
+    }
+
+    tm.tm_year -= 1900;
+    tm.tm_mday += step * days;
+    tm.tm_hour  = seconds / 3600;
+    tm.tm_min   = (seconds % 3600) / 60;
+    tm.tm_sec   = seconds % 60;
+    tm.tm_isdst = -1;
+
+    return &tm;
+}

--- a/sources/localtime.c
+++ b/sources/localtime.c
@@ -6,100 +6,13 @@
 #endif /* __MINTLIB_COMPATIBLE */
 
 
-/* year range is from 1901 to 2038, so no century can occur which is not a leap year
-#define is_leap(y)  ((y) % 4 == 0 && ((y) % 100 != 0 || (y) % 400 == 0))
-*/
-#define is_leap(y)  ((y) % 4 == 0)
-
-
-const long _month_days[] = { 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31 };
-
-enum { January, February, March, April, May, June, July, August, September, October, November, December, Months };
-enum { Sunday, Monday, Tuesday, Wednesday, Thursday, Friday, Saturday, Weekdays };
-
-
 struct tm*
 localtime(const time_t* timep)
 {
-    static struct tm tm;
+    time_t t = *timep;
 
-    time_t t   = *timep;
-    int    neg = (t < 0);
-    int    step;
-    int    days;
-    int    seconds;
-    int    leap;
-    int    monthdays;
+    tzset();
+	t -= timezone;
 
-    if (neg) {
-        t    = -t - 1;
-        step = -1;
-    } else {
-        step = 1;
-    }
-
-    days    = t / 86400;
-    seconds = t % 86400;
-
-    if (neg) {
-        tm.tm_wday = (Wednesday + days) % Weekdays;
-        tm.tm_year = 1969;
-        seconds    = 86399 - seconds;
-    } else {
-        tm.tm_wday = (Thursday + days) % Weekdays;
-        tm.tm_year = 1970;
-    }
-
-    for (;;) {
-        int yeardays = is_leap(tm.tm_year) ? 366 : 365;
-
-        if (neg) {
-            if (yeardays > days) {
-                tm.tm_yday = yeardays - days - 1;
-                break;
-            }
-        } else {
-            if (yeardays >= days) {
-                tm.tm_yday = days;
-                break;
-            }
-        }
-
-        tm.tm_year += step;
-        days       -= yeardays;
-    }
-
-    tm.tm_mon = neg ? 11 : 0;
-
-    leap = is_leap(tm.tm_year);
-
-    for (;;) {
-        monthdays = _month_days[tm.tm_mon];
-
-        if (leap && tm.tm_mon == 1) {
-            ++monthdays;
-        }
-
-        if (monthdays <= days) {
-            tm.tm_mon += step;
-            days      -= monthdays;
-
-            if (tm.tm_mon == 12) {
-                tm.tm_mon = 0;
-                ++tm.tm_year;
-            }
-        } else {
-            tm.tm_mday = neg ? monthdays : 1;
-            break;
-        }
-    }
-
-    tm.tm_year -= 1900;
-    tm.tm_mday += step * days;
-    tm.tm_hour  = seconds / 3600;
-    tm.tm_min   = (seconds % 3600) / 60;
-    tm.tm_sec   = seconds % 60;
-    tm.tm_isdst = -1;
-
-    return &tm;
+    return gmtime(&t);
 }

--- a/sources/mktime.c
+++ b/sources/mktime.c
@@ -29,6 +29,8 @@ time_t mktime(struct tm *tm)
 	long tyears, tdays, leaps, utc_hrs;
     int leap_year;
 
+    tzset();
+
     leap_year = is_leap(tm->tm_year + 1900);
 	tyears = tm->tm_year - 70;
 	leaps = (tyears + 2) / 4;
@@ -54,5 +56,5 @@ time_t mktime(struct tm *tm)
 
     utc_hrs = tm->tm_hour;
 
-    return (tdays * 86400) + (utc_hrs * 3600) + (tm->tm_min * 60) + tm->tm_sec;
+    return (tdays * 86400) + (utc_hrs * 3600) + (tm->tm_min * 60) + tm->tm_sec + timezone;
 }

--- a/sources/strftime.c
+++ b/sources/strftime.c
@@ -22,6 +22,8 @@ strftime(char* s, size_t smax, const char* fmt, const struct tm* tp)
     char*  ptr   = s;
     size_t count = 0;
 
+    tzset();
+
     do {
         if (*fmt == '%') {
             const char* addstr = NULL;
@@ -49,7 +51,7 @@ strftime(char* s, size_t smax, const char* fmt, const struct tm* tp)
                     break;
 
                 case 'c':
-                    strftime(addval, 80, "%a %b %d %x %Y", tp);
+                    strftime(addval, sizeof(addval) - 1, "%a %b %d %x %Y", tp);
                     break;
 
                 case 'd':
@@ -150,7 +152,7 @@ strftime(char* s, size_t smax, const char* fmt, const struct tm* tp)
                     break;
 
                 case 'Z':
-                    addstr = "";
+					addstr = tzname[tp->tm_isdst > 0];
                     break;
 
                 case '%':

--- a/sources/time.c
+++ b/sources/time.c
@@ -1,4 +1,5 @@
 #include <time.h>
+#include <string.h>
 #include <osbind.h>
 #ifdef __MINTLIB_COMPATIBLE
 #	include <sys/time.h>
@@ -26,6 +27,13 @@ int gettimeofday(struct timeval *tp, struct timezone *tzp)
         tp->tv_sec = mktime(&now);
         tp->tv_usec = 0;
     }
+
+	if (tzp != NULL) {
+		tzset();
+		tzp->tz_minuteswest = -timezone / 60;
+		tzp->tz_dsttime     = strcmp(tzname[0], tzname[1]);
+	}
+
     return 0;
 }
 

--- a/sources/tzset.c
+++ b/sources/tzset.c
@@ -1,0 +1,151 @@
+#include <time.h>
+#include <string.h>
+#include <osbind.h>
+#ifdef __MINTLIB_COMPATIBLE
+#	include <sys/time.h>
+#endif
+
+
+#ifndef TZ_STRLEN_MAX
+# define TZ_STRLEN_MAX  255
+#endif /* !defined TZ_STRLEN_MAX */
+
+#ifndef TZ_DEFAULT
+# define TZ_DEFAULT	"   "
+#endif /* !defined TZ_DEFAULT */
+
+#define ISDIGIT(c)  ((c) >= '0' && (c) <= '9')
+
+
+static char _tzname[2][TZ_STRLEN_MAX + 1] = { "", "" };
+static char	_tzval[TZ_STRLEN_MAX + 1]     = "";
+static int	_tzset                        = 0;
+static char _tzdflt[]                     = TZ_DEFAULT;
+
+
+int   _bios_is_gmt = 0;
+long  timezone     = 0L;
+char* tzname[2]    = { _tzdflt, _tzdflt };
+
+
+const char* get_tz_name(const char* src, char* dest);
+const char* get_tz_offset(const char* src, int* error);
+
+
+void
+tzset()
+{
+    const char* tzval = getenv("TZ");
+
+    if (tzval == NULL) {
+		tzval = "";
+	}
+
+	if (!_tzset || strcmp(_tzval, tzval) != 0) {
+		int error;
+
+		_tzset = (strlen(tzval) < sizeof(_tzval));
+
+		if (_tzset) {
+			strcpy(_tzval, tzval);
+		}
+
+		tzval = get_tz_name(tzval, _tzname[0]);
+		tzval = get_tz_offset(tzval, &error);
+
+		if (error) {
+			tzname[0] = _tzdflt;
+			tzname[1] = _tzdflt;
+		} else {
+			tzval = get_tz_name(tzval, _tzname[1]);
+
+			tzname[0] = _tzname[0];
+			tzname[1] = _tzname[1];
+		}
+	}
+}
+
+
+const char*
+get_tz_name(const char* src, char* dest)
+{
+	int tzlen = 0;
+
+	if (*src != ':') {
+		while (*src != '\0' && *src != ',' && *src != '+' && *src != '-' && !ISDIGIT(*src) && tzlen < TZ_STRLEN_MAX) {
+			*dest++ = *src++;
+			++tzlen;
+		}
+	}
+
+	if (tzlen == 0) {
+		strcpy(dest, _tzdflt);
+	} else {
+		*dest = '\0';
+	}
+
+	return src;
+}
+
+
+const char*
+get_tz_offset(const char* src, int* error)
+{
+	if (*src == '\0') {
+		timezone = 0;
+		*error   = 0;
+	} else {
+		enum { Hours, Minutes, Seconds };
+
+		int tim[3] = { 0, 0, 0 };
+		int mul    = 1;
+
+		register int i;
+
+		if (*src == '-') {
+			mul = -1;
+			++src;
+		} else if (*src == '+') {
+			++src;
+		}
+
+		for (i = 0; i < sizeof(tim) / sizeof(tim[0]); ++i) {
+			if (*src == '\0') {
+				// invalid
+				mul = 0;
+			} else if (ISDIGIT(*src)) {
+				tim[i] = *src++ - '0';
+
+				if (ISDIGIT(*src)) {
+					tim[i] = 10 * tim[i] + *src++ - '0';
+
+					if (ISDIGIT(*src)) {
+						// not more than two digits allowed
+						mul = 0;
+					}
+				}
+			}
+
+			if (mul == 0) {
+				// invalid offset format
+				break;
+			} else if (*src == ':') {
+				// next field
+				++src;
+			} else {
+				// end of offset information
+				break;
+			}
+		}
+
+		if (tim[Minutes] > 59 || tim[Seconds] > 59) {
+			// invalid minutes or seconds
+			mul = 0;
+		}
+
+		timezone = mul * (tim[Seconds] + 60 * tim[Minutes] + 3600 * tim[Hours]);
+		*error   = (mul == 0);
+	}
+
+	return src;
+}


### PR DESCRIPTION
New functions in time.h: gmtime() and tzset()
New global variables in time.h: localtime, tzname[]

Timezone support is implemented with parsing the TZ environment variable as described here:
https://users.pja.edu.pl/~jms/qnx/help/watcom/clibref/global_data.html#TheTZEnvironmentVariable

Due to the lack of DST support, the rule part of the TZ variable will not be interpreted.

The time functions assume the system time to be local time rather than UTC, because that is the usual setup (see comment in time.h -> GMT_BIOS_CLOCK).

Some TZ examples:
Central European Time: CET-1
Central European Summer Time: CEST-2
Afghanistan Time: AFT-4:30
Japanese Standard Time: JST-9
Eastern Standard Time: EST+5
Pacific Standard Time: PST+9
Greenwich Mean Time: GMT

The offset must be given in time to add to reach UTC, not the difference to UTC. So, you must subtract one hour from CET to reach UTC. Therefore it's CET-1 and not CET+1. The offset format is [+|-]hh[:mm[:ss]]. The + for positive values is optional. Hours can be from -99 up to 99. Minutes can be from 0 up to 59, same for seconds. Any invalid offset will lead to as if no timezone would be set.