### PR TITLE
Add include of optional Make.config.local to Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+
+Make.config.local

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,13 @@ else
   	CROSSPREFIX=m68k-atari-mint-
 endif
 
+CFLAGS=\
+	   -Wall\
+	   -Os \
+	   -fomit-frame-pointer
+
 -include Make.config
+-include Make.config.local
 
 CC=$(CROSSPREFIX)gcc
 LD=$(CROSSPREFIX)ld
@@ -43,11 +49,6 @@ CPP=$(CROSSPREFIX)cpp
 OBJCOPY=$(CROSSPREFIX)objcopy
 AR=$(CROSSPREFIX)ar
 RANLIB=$(CROSSPREFIX)ranlib
-
-CFLAGS=\
-	   -Wall\
-	   -Os \
-	   -fomit-frame-pointer
 
 ifeq (,$(filter $(MINTLIB_COMPATIBLE),Y yes))
 	INCLUDE=-Iinclude


### PR DESCRIPTION
The intention is to provide a way to play around with the configuration variables such as ONLY_68K etc. and CFLAGS without modifying Makefile and maybe forgetting to undo such changes.

Make.config.local is now added to .gitignore to ensure that these local configuration will not be pushed to the repository.