### PR TITLE
Fix bug that causes memcpy() etc. to crash when size parameter is 0

### DIFF
--- a/sources/bcopy.S
+++ b/sources/bcopy.S
@@ -74,7 +74,7 @@ __bcopy:
 
 _memcpy:
 _memmove:
-	tst.l	d0
+	tst.l	d0	
 
 #endif /* __FASTCALL__ */
 
@@ -200,8 +200,8 @@ less2:
 none:
 exit_d2:
 	move.l	(sp)+,d2
-	move.l	(sp)+,a0
 exit:
+	move.l	(sp)+,a0
 	move.l 	a0,d0		| return dest (for memcpy only)
 	rts
 

--- a/sources/bcopy.S
+++ b/sources/bcopy.S
@@ -74,7 +74,7 @@ __bcopy:
 
 _memcpy:
 _memmove:
-	tst.l	d0	
+	tst.l	d0
 
 #endif /* __FASTCALL__ */
 
@@ -200,8 +200,8 @@ less2:
 none:
 exit_d2:
 	move.l	(sp)+,d2
-exit:
 	move.l	(sp)+,a0
+exit:
 	move.l 	a0,d0		| return dest (for memcpy only)
 	rts
 


### PR DESCRIPTION
When size is 0, the stack must not be corrected before returning!
Fixes #82 