### PR TITLE
Fix overflow in strtod mantissa read when sizeof(int) is 2

### DIFF
--- a/sources/strtod.c
+++ b/sources/strtod.c
@@ -204,7 +204,7 @@ STRTOF(const char* string, char** endPtr)
     p = string;
     goto done;
     } else {
-    int frac1, frac2;
+    long frac1, frac2;
     frac1 = 0;
     for ( ; mantSize > 9; mantSize -= 1)
     {


### PR DESCRIPTION
The mantissa read loop in strtod reads 18 digits using two ints to convert nine digits each. When sizeof(int) is 2 the conversion value overflows. To fix this the types of frac1 and frac2 have been changed to long.

Example:
  printf("val f: %f\n", strtof("0.123456789012345678",NULL));
  printf("val d: %f\n", strtod("0.123456789012345678",NULL));

Without fix:
  val f: 0.000249
  val d: 0.000249

With fix:
  val f: 0.123457
  val d: 0.123457