### PR TITLE
Fixes #142

### DIFF
--- a/sources/strncpy.c
+++ b/sources/strncpy.c
@@ -10,7 +10,7 @@
 char *strncpy(char *dst, const char *src, size_t max)
 {
 	char *dscan;
-	unsigned long count;
+	size_t count;
 
 	dscan = dst;
 	count = max;


### PR DESCRIPTION
Changed `count` variable from long to size_t to avoid truncation as noted in https://github.com/freemint/libcmini/issues/142