### PR TITLE
Fix strftime() format specifier bugs

### DIFF
--- a/sources/strftime.c
+++ b/sources/strftime.c
@@ -62,7 +62,7 @@ size_t strftime(char *s, size_t smax, const char *fmt, const struct tm *tp)
 				{
 					addstr = "?";
 					addlen = -1;
-				} else 
+				} else
 				{
 					addstr = wday_name[tp->tm_wday];
 				}
@@ -159,17 +159,16 @@ size_t strftime(char *s, size_t smax, const char *fmt, const struct tm *tp)
 				break;
 
 			case 'w':
-				addval[0] = '0' + (tp->tm_wday / 10);
-				addval[1] = '0' + (tp->tm_wday % 10);
-				addval[2] = '\0';
+				addval[0] = '0' + (tp->tm_wday % 10);
+				addval[1] = '\0';
 				break;
 
 			case 'X':
-				strftime(addval, 80, "%d.%m.%Y", tp);
+				strftime(addval, 80, "%H:%M:%S", tp);
 				break;
 
 			case 'x':
-				strftime(addval, 80, "%H:%M:%S", tp);
+				strftime(addval, 80, "%d.%m.%Y", tp);
 				break;
 
 			case 'y':


### PR DESCRIPTION
- %w returns the day of the week as a single digit instead of two digits.
- %X returns the time instead of the date.
- %x returns the date instead of the time.