### PR TITLE
Fixed a bug and made a few minor performance improvements.

### DIFF
--- a/sources/delay.c
+++ b/sources/delay.c
@@ -14,11 +14,11 @@
    since it's easier to simly use timer C (200 Hz / 5 ms).
 */
 
-void
-delay(unsigned long milliseconds)
+void delay(unsigned long milliseconds)
 {
-	clock_t cycles = milliseconds / 5;
-	clock_t start  = clock();
+	clock_t cycles = milliseconds / (1000 / CLOCKS_PER_SEC);
+	clock_t end    = clock() + cycles;
 
-	do {} while (clock() - start < cycles);
+	do {} while (clock() < end);
+    ;
 }

--- a/sources/doprnt.c
+++ b/sources/doprnt.c
@@ -44,15 +44,14 @@ static int normalize_float(double* valptr, int round_to, int eformat);
 #define ISLOWER(c)  ((c) >= 'a' && (c) <= 'z')
 
 
-int
-doprnt(int (*addchar)(int, void*), void* stream, const char* sfmt, va_list ap)
+int doprnt(int (*addchar)(int, void*), void *stream, const char *sfmt, va_list ap)
 {
     enum { INT_VAL, LONG_VAL, LONG_LONG_VAL };
 
     int  fmt;
     char pad           = ' ';
     int  flush_left    = FALSE;
-    int  field_width   = 0;
+    register int field_width = 0;
     int  precision     = UNLIMITED;
     int  hash          = FALSE;
     char space_or_sign = '\0';
@@ -83,49 +82,34 @@ doprnt(int (*addchar)(int, void*), void* stream, const char* sfmt, va_list ap)
             unsigned long long ulonglongval;
         #endif /* STDIO_WITH_LONG_LONG */
 
-            int flag_found;
-
-            ++f; /* skip the % */
-
-            do {
-                flag_found = TRUE;
-
-                switch (*f) {
+            while (1) {
+                switch (*++f) {
                     case '-':
                         /* minus: flush left */
                         flush_left = TRUE;
-                        break;
-
+                        continue;
                     case '+':
                         /* plus: numbers always with sign */
                         space_or_sign = '+';
-                        break;
-
+                        continue;
                     case ' ':
                         /* space: numbers without sign start with space */
                         space_or_sign = ' ';
-                        break;
-
+                        continue;
                     case '0':
                         /* padding with 0 rather than blank */
                         pad = '0';
-                        break;
-
+                        continue;
                     case '#':
                         /* alternate form */
                         hash = TRUE;
-                        break;
-
+                        continue;
                     default:
-                        flag_found = FALSE;
                         break;
-
                 }
 
-                if (flag_found) {
-                    ++f;
-                }
-            } while (flag_found);
+                break;
+            }
 
             if (*f == '*') {
                 /* field width */
@@ -175,7 +159,7 @@ doprnt(int (*addchar)(int, void*), void* stream, const char* sfmt, va_list ap)
 
             fmt = (unsigned char)*f;
 
-            if (fmt != 'S' && fmt != 'Q' && fmt != 'X' && fmt != 'E' && fmt != 'G' && ISUPPER(fmt)) {
+            if (ISUPPER(fmt) && fmt != 'S' && fmt != 'Q' && fmt != 'X' && fmt != 'E' && fmt != 'G') {
                 do_long = LONG_VAL;
                 fmt    |= 0x20 /* tolower */;
             }
@@ -376,7 +360,7 @@ doprnt(int (*addchar)(int, void*), void* stream, const char* sfmt, va_list ap)
 
                         exponent = normalize_float(&floatval, precision, (fmt | 0x20 /* tolower */) == 'e');
 
-                        switch (tolower(fmt)) {
+                        switch (fmt | 0x20 /* tolower */) {
                             case 'e':
                                 use_exp_format = TRUE;
                                 break;
@@ -660,20 +644,19 @@ doprnt(int (*addchar)(int, void*), void* stream, const char* sfmt, va_list ap)
                         if(hash) {
                             switch (fmt) {
                                 case 'X':
-                                case 'x':
-                                    prefix = "x0";
-                                    *(char*)prefix = fmt;
+                                    prefix = "X0";
                                     len_prefix = 2;
                                     break;
-
+                                case 'x':
+                                    prefix = "x0";
+                                    len_prefix = 2;
+                                    break;
                                 case 'o':
                                     prefix = "0";
                                     len_prefix = 1;
                                     break;
-
                                 default:
                                     break;
-
                             }
                         }
 
@@ -792,7 +775,12 @@ doprnt(int (*addchar)(int, void*), void* stream, const char* sfmt, va_list ap)
                             bufptr = "(nil)";
                         }
 
-                        field_width -= (int)strlen(bufptr);
+                        {
+                            /* avoid calling strlen() */
+                            register char *s = bufptr;
+                            while (*s) ++s;
+                            field_width -= (int)(s - bufptr);
+                        }
 
                         if (!flush_left) {
                             while (field_width-- > 0) {

--- a/sources/doprnt.c
+++ b/sources/doprnt.c
@@ -51,7 +51,7 @@ int doprnt(int (*addchar)(int, void*), void *stream, const char *sfmt, va_list a
     int  fmt;
     char pad           = ' ';
     int  flush_left    = FALSE;
-    register int field_width = 0;
+    int  field_width   = 0;
     int  precision     = UNLIMITED;
     int  hash          = FALSE;
     char space_or_sign = '\0';
@@ -775,12 +775,7 @@ int doprnt(int (*addchar)(int, void*), void *stream, const char *sfmt, va_list a
                             bufptr = "(nil)";
                         }
 
-                        {
-                            /* avoid calling strlen() */
-                            register char *s = bufptr;
-                            while (*s) ++s;
-                            field_width -= (int)(s - bufptr);
-                        }
+                        field_width -= (int)strlen(bufptr);
 
                         if (!flush_left) {
                             while (field_width-- > 0) {

--- a/sources/fclose.c
+++ b/sources/fclose.c
@@ -7,6 +7,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <errno.h>
 #include <mint/osbind.h>
 #include "lib.h"
 
@@ -15,20 +16,34 @@ int fclose(FILE *fp)
 {
 	if (fp && fp->__magic == _IOMAGIC)
 	{
-		FILE **prev;
-		
-		Fclose(FILE_GET_HANDLE(fp));
-		FILE_SET_HANDLE(fp, -7);
-		fp->__magic = 0;
+        int r;
 
-		prev = &__stdio_head;
-		for (prev = &__stdio_head; (*prev) && *prev != fp; prev = &(*prev)->__next)
-			;
-		if (*prev == fp)
-		{
-			*prev = fp->__next;
-			free(fp);
-		}
-	}
+        r = Fclose(FILE_GET_HANDLE(fp));
+        if (r < 0) {
+            __set_errno (-r);
+            return EOF;
+        } else
+        {
+            FILE **prev;
+
+            FILE_SET_HANDLE(fp, -7);
+            fp->__magic = 0;
+
+            prev = &__stdio_head;
+            for (prev = &__stdio_head; (*prev) && *prev != fp; prev = &(*prev)->__next)
+                ;
+            if (*prev == fp)
+            {
+                *prev = fp->__next;
+                free(fp);
+            }
+
+            return 0;
+        }
+	} else
+    {
+        __set_errno (EINVAL);
+        return EOF;
+    }
 	return 0;
 }

--- a/sources/sleep.c
+++ b/sources/sleep.c
@@ -9,12 +9,12 @@
 #include <time.h>
 
 
-unsigned int
-sleep(unsigned int seconds)
+unsigned int sleep(unsigned int seconds)
 {
 	clock_t cycles = seconds * CLOCKS_PER_SEC;
-	clock_t start  = clock();
+	clock_t end    = clock() + cycles;
 
-	do {} while (clock() - start < cycles);
+	do {} while (clock() < end);
+
 	return 0;
 }


### PR DESCRIPTION
`delay.c` / `sleep.c`:
Subtraction removed from while condition.

`fclose.c`:
Error handling has been added; `errno` is set in case of an error. For example, `fclose(NULL)` now correctly returns `EOF` instead of `0`.

`doprnt.c`:
Bug fixed and performance improved:
- `field_width` is now `register int`
- Redundant `flag_found` removed and loop adjusted accordingly
- `ISUPPER()` in the condition for `do_long = LONG_VAL` moved from the very end to the very beginning
- `tolower(fmt)` replaced with `fmt | 0x20` at a point where only 'e' and 'g' are checked
- Bugfix: String literal manipulation replaced
  - instead of (when `fmt == 'x'` or `fmt == 'X'`):
`prefix = "x0";`
`*(char*)prefix = fmt;`
...
  - now (when `fmt == 'x'`):
`prefix = "x0";`
...
  - and (when `fmt == 'X'`):
`prefix = "X0";`
...
- Use of `strlen()` replaced with manual counting